### PR TITLE
Mailcatcher isn't installing

### DIFF
--- a/chef/shell/initial.sh
+++ b/chef/shell/initial.sh
@@ -6,11 +6,11 @@ VAGRANT_DIR="/vagrant"
 cat "$VAGRANT_DIR/chef/shell/vdd.txt"
 
 # Upgrade Chef.
-echo "Updating Chef to 11.12.4 version. This may take a few minutes..."
 apt-get update &> /dev/null
 echo "sources updated"
 echo "installing ruby and chef"
-apt-get install build-essential ruby1.9.1-dev --no-upgrade --yes
+apt-get install build-essential ruby2.0 ruby2.0-dev chef --yes
+ln -sf /usr/bin/ruby2.0 /usr/bin/ruby
+ln -sf /usr/bin/gem2.0 /usr/bin/gem
 update-ca-certificates
-gem install chef --version="11.12.4" --no-rdoc --no-ri --conservative
 echo "installed ruby and chef"


### PR DESCRIPTION
**mime-types-data** (mailcatcher dependency) requires Ruby version >= 2.0 :

```
==> default: ================================================================================
==> default: Error executing action `install` on resource 'gem_package[mailcatcher]'
==> default: ================================================================================
==> default:
==> default:
==> default: Gem::InstallError
==> default: -----------------
==> default: mime-types-data requires Ruby version >= 2.0.
==> default:
==> default:
==> default: Resource Declaration:
==> default: ---------------------
==> default: # In /vagrant/chef/cookbooks/core/vdd/recipes/mailcatcher.rb
==> default:
==> default:   5: gem_package "mailcatcher" do
==> default:   6:   action :install
==> default:   7: end
==> default:   8:
```

This pull request install ruby / gem 2.0 
